### PR TITLE
[shelly-connector][redisdb-plugin] Use optimistic state update

### DIFF
--- a/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/ChannelPropertiesManager.php
+++ b/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/ChannelPropertiesManager.php
@@ -62,6 +62,7 @@ class ChannelPropertiesManager implements DevicesModels\States\Channels\IManager
 	}
 
 	/**
+	 * @throws RedisDbExceptions\InvalidArgument
 	 * @throws RedisDbExceptions\InvalidState
 	 */
 	public function update(Uuid\UuidInterface $id, Utils\ArrayHash $values): States\ChannelProperty|false

--- a/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/ConnectorPropertiesManager.php
+++ b/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/ConnectorPropertiesManager.php
@@ -62,6 +62,7 @@ class ConnectorPropertiesManager implements DevicesModels\States\Connectors\IMan
 	}
 
 	/**
+	 * @throws RedisDbExceptions\InvalidArgument
 	 * @throws RedisDbExceptions\InvalidState
 	 */
 	public function update(Uuid\UuidInterface $id, Utils\ArrayHash $values): States\ConnectorProperty|false

--- a/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/DevicePropertiesManager.php
+++ b/src/FastyBird/Bridge/RedisDbPluginDevicesModule/src/Models/States/DevicePropertiesManager.php
@@ -62,6 +62,7 @@ class DevicePropertiesManager implements DevicesModels\States\Devices\IManager
 	}
 
 	/**
+	 * @throws RedisDbExceptions\InvalidArgument
 	 * @throws RedisDbExceptions\InvalidState
 	 */
 	public function update(Uuid\UuidInterface $id, Utils\ArrayHash $values): States\DeviceProperty|false

--- a/src/FastyBird/Bridge/RedisDbPluginTriggersModule/src/Models/States/ActionsManager.php
+++ b/src/FastyBird/Bridge/RedisDbPluginTriggersModule/src/Models/States/ActionsManager.php
@@ -62,6 +62,7 @@ class ActionsManager implements TriggersModels\States\IActionsManager
 	}
 
 	/**
+	 * @throws RedisDbExceptions\InvalidArgument
 	 * @throws RedisDbExceptions\InvalidState
 	 */
 	public function update(Uuid\UuidInterface $id, Utils\ArrayHash $values): States\Action|false

--- a/src/FastyBird/Bridge/RedisDbPluginTriggersModule/src/Models/States/ConditionsManager.php
+++ b/src/FastyBird/Bridge/RedisDbPluginTriggersModule/src/Models/States/ConditionsManager.php
@@ -62,6 +62,7 @@ class ConditionsManager implements TriggersModels\States\IConditionsManager
 	}
 
 	/**
+	 * @throws RedisDbExceptions\InvalidArgument
 	 * @throws RedisDbExceptions\InvalidState
 	 */
 	public function update(Uuid\UuidInterface $id, Utils\ArrayHash $values): States\Condition|false

--- a/src/FastyBird/Connector/Shelly/src/Queue/Consumers/WriteChannelPropertyState.php
+++ b/src/FastyBird/Connector/Shelly/src/Queue/Consumers/WriteChannelPropertyState.php
@@ -34,9 +34,11 @@ use FastyBird\Module\Devices\Documents as DevicesDocuments;
 use FastyBird\Module\Devices\Exceptions as DevicesExceptions;
 use FastyBird\Module\Devices\Models as DevicesModels;
 use FastyBird\Module\Devices\Queries as DevicesQueries;
+use FastyBird\Module\Devices\States as DevicesStates;
 use FastyBird\Module\Devices\Types as DevicesTypes;
 use Fig\Http\Message\StatusCodeInterface;
 use Nette;
+use Nette\Utils;
 use RuntimeException;
 use Throwable;
 use TypeError;
@@ -419,7 +421,17 @@ final class WriteChannelPropertyState implements Queue\Consumer
 		}
 
 		$result->then(
-			function () use ($message, $connector, $device, $channel, $property): void {
+			function () use ($message, $connector, $device, $channel, $property, $state): void {
+				await($this->channelPropertiesStatesManager->set(
+					$property,
+					Utils\ArrayHash::from([
+						DevicesStates\Property::ACTUAL_VALUE_FIELD => $state->getExpectedValue(),
+						DevicesStates\Property::EXPECTED_VALUE_FIELD => null,
+						DevicesStates\Property::PENDING_FIELD => false,
+					]),
+					MetadataTypes\Sources\Connector::SHELLY,
+				));
+
 				$this->logger->debug(
 					'Channel state was successfully sent to device',
 					[

--- a/src/FastyBird/Plugin/RedisDb/src/Models/States/StatesManager.php
+++ b/src/FastyBird/Plugin/RedisDb/src/Models/States/StatesManager.php
@@ -112,6 +112,7 @@ class StatesManager
 	/**
 	 * @phpstan-return T
 	 *
+	 * @throws Exceptions\InvalidArgument
 	 * @throws Exceptions\InvalidState
 	 */
 	public function update(
@@ -125,6 +126,8 @@ class StatesManager
 
 		} catch (Exceptions\NotUpdated) {
 			return false;
+		} catch (Exceptions\NotFound) {
+			$raw = $this->createKey($id, $values, $this->entity::getCreateFields(), $database);
 		}
 
 		try {
@@ -253,7 +256,7 @@ class StatesManager
 			$raw = $this->client->get($id->toString());
 
 			if (!is_string($raw)) {
-				throw new Exceptions\InvalidState('Stored record could not be loaded from database');
+				throw new Exceptions\NotFound('Stored record could not be loaded from database');
 			}
 
 			$data = Utils\Json::decode($raw);


### PR DESCRIPTION
- For cases when the CoAP messages are not present, or delayed, we update device state if the api call was successful 